### PR TITLE
Add grpahql Mutations to demonstrate CRUD.

### DIFF
--- a/src/helper/MarvelApi.js
+++ b/src/helper/MarvelApi.js
@@ -1,9 +1,10 @@
-import crypto from 'crypto';
-import fetch from 'node-fetch';
+import crypto from 'crypto'
+import fetch from 'node-fetch'
 
 // Import classes to assist with formatting the API response into a structure
 // that represents the GraphQL Schema for the type in the graphql server.
-import { Model as Comic } from '../types/comic';
+import { Model as Comic } from '../types/comic'
+import { Model as Character } from '../types/hero'
 
 /**
 ---- ENVIRONMENT VARIABLES ----
@@ -36,12 +37,19 @@ class MarvelApi {
     console.log(error);
   }
 
-  characters() {
-    const url = `${this.url}/characters?${this.params}`;
+  characters(name = null) {
+    let params = this.params
+    if (!!name) {
+      params += `&name=${name}`
+    }
+
+    const url = `${this.url}/characters?${params}`;
 
     return fetch(url)
       .then(res => res.json())
-      .then()
+      .then(json => {
+        return json.data.results.map(i => new Character(i))
+      })
       .catch(this.handleErrors);
   }
 

--- a/src/types/hero.js
+++ b/src/types/hero.js
@@ -14,6 +14,10 @@ const schema = `
     villains: [Villain]
     comics: [Comic]
   }
+
+  input HeroName {
+    name: String
+  }
 `;
 
 export const queries = `
@@ -21,13 +25,43 @@ export const queries = `
   hero(id: Int!): Hero
 `;
 
+export const mutations = `
+  updateHero(id: Int! input:HeroName!): Hero
+  createHero(input:HeroName!):[Hero]
+`
+
 const heroes = () => heroesList;
 const hero = (_, { id }) => heroesList.find(hero => hero.id === id);
+const updateHero = (_, { id, input }) => {
+  const _hero = hero(_, { id })
+  const { name } = input
+
+  if (!_hero) {
+    throw new Error(`Couldn't find a hero with an id of ${id}`)
+  }
+
+  _hero.name = name
+  return _hero
+}
+
+const createHero = (_, { input }) => {
+  const { name } = input;
+  return MarvelApi.characters(name).then(characters => {
+    if (characters.length > 0) {
+      heroesList.push(characters[0]);
+    }
+    return heroesList
+  })
+}
 
 const resolvers = {
   queries: {
     heroes,
     hero
+  },
+  mutations: {
+    updateHero,
+    createHero
   },
   Hero: {
     villains: ({ villains }) => {
@@ -41,9 +75,28 @@ const resolvers = {
   }
 }
 
+/**
+ * --- CLASS MODEL ---
+ *
+ * A model can be used to massage the data received from a remote source (db,
+ * api, etc.) into the schema known by GraphQL.
+ */
+export class Model {
+  constructor({ id, name, description, thumbnail }) {
+    this.id = id;
+    this.name = name;
+    this.description = description;
+    this.image = `${thumbnail.path}.${thumbnail.extension}`;
+    this.villains = [];
+    this.comics = [];
+  }
+}
+/** ---- */
+
 export default () => ({
   schema,
   queries,
+  mutations,
   resolvers,
   modules: [villains, comics]
 })


### PR DESCRIPTION
- Adds mutations to the hero API calls to demonstrate how CRUD
operations can be managed with GraphQL.

The heroList will be maintained in memory (rather than another database
call) just to demonstrate the results of using graphql.